### PR TITLE
chore: Correct sync-server to async-server in test failure message

### DIFF
--- a/tests/go/integration_test.go
+++ b/tests/go/integration_test.go
@@ -299,7 +299,7 @@ func TestAsync(t *testing.T) {
 
 	stop, err := async_server.Serve(client, integration.AsyncHandler{})
 	if err != nil {
-		t.Errorf("failed to serve `sync-server` world: %s", err)
+		t.Errorf("failed to serve `async-server` world: %s", err)
 		return
 	}
 


### PR DESCRIPTION
Since I [noticed this](https://github.com/wrpc/wrpc/pull/52#discussion_r1598938398) while looking through #52, I figured I should just submit a PR to fix it :)