### PR TITLE
ci: Add Go modules updates via dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,7 @@ updates:
   directory: "/"
   schedule:
     interval: "daily"
+- package-ecosystem: "gomod"
+  directory: "/go"
+  schedule:
+    interval: "daily"


### PR DESCRIPTION
Since there's a Go version included in the repository, it feels like it's worth keeping Dependabot's eyes on the modules that are included.