### PR TITLE
feat(wit-bindgen-rust) Implement resource handle support for `wit-bindgen-wrpc`

### DIFF
--- a/crates/transport-legacy/src/lib.rs
+++ b/crates/transport-legacy/src/lib.rs
@@ -2774,7 +2774,7 @@ impl<T: Send + Sync> Encode for &ResourceOwn<T> {
         self,
         payload: &mut (impl bytes::BufMut + Send),
     ) -> anyhow::Result<Option<AsyncValue>> {
-        self.data.clone().encode(payload).await
+        self.data.as_slice().encode(payload).await
     }
 }
 
@@ -2839,7 +2839,7 @@ impl<T: Send + Sync> Encode for &ResourceBorrow<T> {
         self,
         payload: &mut (impl bytes::BufMut + Send),
     ) -> anyhow::Result<Option<AsyncValue>> {
-        self.data.clone().encode(payload).await
+        self.data.as_slice().encode(payload).await
     }
 }
 

--- a/crates/transport-legacy/src/lib.rs
+++ b/crates/transport-legacy/src/lib.rs
@@ -2731,19 +2731,19 @@ impl Encode for Value {
 }
 
 // Resource Handles
-#[derive(Debug, Clone)]
-pub struct ResourceOwn<T: Clone + Send + Sync> {
+#[derive(Debug)]
+pub struct ResourceOwn<T: Send + Sync> {
     data: Vec<u8>,
     _ty: PhantomData<T>,
 }
 
-impl<T: Clone + Send + Sync> AsRef<[u8]> for ResourceOwn<T> {
+impl<T: Send + Sync> AsRef<[u8]> for ResourceOwn<T> {
     fn as_ref(&self) -> &[u8] {
         &self.data
     }
 }
 
-impl<T: Clone + Send + Sync> From<Vec<u8>> for ResourceOwn<T> {
+impl<T: Send + Sync> From<Vec<u8>> for ResourceOwn<T> {
     fn from(value: Vec<u8>) -> Self {
         Self {
             data: value,
@@ -2752,14 +2752,14 @@ impl<T: Clone + Send + Sync> From<Vec<u8>> for ResourceOwn<T> {
     }
 }
 
-impl<T: Clone + Send + Sync> From<ResourceOwn<T>> for Vec<u8> {
+impl<T: Send + Sync> From<ResourceOwn<T>> for Vec<u8> {
     fn from(value: ResourceOwn<T>) -> Self {
         value.data
     }
 }
 
 #[async_trait]
-impl<T: Clone + Send + Sync> Encode for ResourceOwn<T> {
+impl<T: Send + Sync> Encode for ResourceOwn<T> {
     async fn encode(
         self,
         payload: &mut (impl bytes::BufMut + Send),
@@ -2769,7 +2769,7 @@ impl<T: Clone + Send + Sync> Encode for ResourceOwn<T> {
 }
 
 #[async_trait]
-impl<T: Clone + Send + Sync> Encode for &ResourceOwn<T> {
+impl<T: Send + Sync> Encode for &ResourceOwn<T> {
     async fn encode(
         self,
         payload: &mut (impl bytes::BufMut + Send),
@@ -2779,7 +2779,7 @@ impl<T: Clone + Send + Sync> Encode for &ResourceOwn<T> {
 }
 
 #[async_trait]
-impl<'a, T: Clone + Send + Sync> Receive<'a> for ResourceOwn<T> {
+impl<'a, T: Send + Sync> Receive<'a> for ResourceOwn<T> {
     #[instrument(level = "trace", skip_all, fields(ty = "resource"))]
     async fn receive<S>(
         payload: impl Buf + Send + 'a,
@@ -2794,21 +2794,21 @@ impl<'a, T: Clone + Send + Sync> Receive<'a> for ResourceOwn<T> {
     }
 }
 
-impl<T: Clone + Send + Sync> Subscribe for ResourceOwn<T> {}
+impl<T: Send + Sync> Subscribe for ResourceOwn<T> {}
 
-#[derive(Debug, Clone)]
-pub struct ResourceBorrow<T: Clone + Send + Sync> {
+#[derive(Debug)]
+pub struct ResourceBorrow<T: Send + Sync> {
     data: Vec<u8>,
     _ty: PhantomData<T>,
 }
 
-impl<T: Clone + Send + Sync> AsRef<[u8]> for ResourceBorrow<T> {
+impl<T: Send + Sync> AsRef<[u8]> for ResourceBorrow<T> {
     fn as_ref(&self) -> &[u8] {
         &self.data
     }
 }
 
-impl<T: Clone + Send + Sync> From<Vec<u8>> for ResourceBorrow<T> {
+impl<T: Send + Sync> From<Vec<u8>> for ResourceBorrow<T> {
     fn from(value: Vec<u8>) -> Self {
         Self {
             data: value,
@@ -2817,14 +2817,14 @@ impl<T: Clone + Send + Sync> From<Vec<u8>> for ResourceBorrow<T> {
     }
 }
 
-impl<T: Clone + Send + Sync> From<ResourceBorrow<T>> for Vec<u8> {
+impl<T: Send + Sync> From<ResourceBorrow<T>> for Vec<u8> {
     fn from(value: ResourceBorrow<T>) -> Self {
         value.data
     }
 }
 
 #[async_trait]
-impl<T: Clone + Send + Sync> Encode for ResourceBorrow<T> {
+impl<T: Send + Sync> Encode for ResourceBorrow<T> {
     async fn encode(
         self,
         payload: &mut (impl bytes::BufMut + Send),
@@ -2834,7 +2834,7 @@ impl<T: Clone + Send + Sync> Encode for ResourceBorrow<T> {
 }
 
 #[async_trait]
-impl<T: Clone + Send + Sync> Encode for &ResourceBorrow<T> {
+impl<T: Send + Sync> Encode for &ResourceBorrow<T> {
     async fn encode(
         self,
         payload: &mut (impl bytes::BufMut + Send),
@@ -2844,7 +2844,7 @@ impl<T: Clone + Send + Sync> Encode for &ResourceBorrow<T> {
 }
 
 #[async_trait]
-impl<'a, T: Clone + Send + Sync> Receive<'a> for ResourceBorrow<T> {
+impl<'a, T: Send + Sync> Receive<'a> for ResourceBorrow<T> {
     #[instrument(level = "trace", skip_all, fields(ty = "resource"))]
     async fn receive<S>(
         payload: impl Buf + Send + 'a,
@@ -2859,7 +2859,7 @@ impl<'a, T: Clone + Send + Sync> Receive<'a> for ResourceBorrow<T> {
     }
 }
 
-impl<T: Clone + Send + Sync> Subscribe for ResourceBorrow<T> {}
+impl<T: Send + Sync> Subscribe for ResourceBorrow<T> {}
 
 pub trait Acceptor {
     type Subject;

--- a/crates/wit-bindgen-rust/src/interface.rs
+++ b/crates/wit-bindgen-rust/src/interface.rs
@@ -210,7 +210,6 @@ impl InterfaceGenerator<'_> {
                     self.push_str(")>> + Send");
                 }
             }
-            // }
             self.src.push_str(";\n");
             let trait_method = mem::replace(&mut self.src, prev);
             methods.push(trait_method);
@@ -593,14 +592,7 @@ pub async fn serve_interface<T: {wrpc_transport}::Client, U>(
         let anyhow = self.gen.anyhow_path();
         uwriteln!(self.src, "use {anyhow}::Context as _;");
         self.src.push_str("let wrpc__ = wrpc__.invoke_static(");
-        match func.kind {
-            FunctionKind::Freestanding
-            | FunctionKind::Static(..)
-            | FunctionKind::Constructor(..)
-            | FunctionKind::Method(..) => {
-                uwrite!(self.src, r#""{instance}""#);
-            }
-        }
+        uwrite!(self.src, r#""{instance}""#);
         self.src.push_str(r#", ""#);
         self.src.push_str(&func.name);
         self.src.push_str(r#"", "#);

--- a/crates/wit-bindgen-rust/src/interface.rs
+++ b/crates/wit-bindgen-rust/src/interface.rs
@@ -162,7 +162,6 @@ impl InterfaceGenerator<'_> {
             };
             funcs_to_export.push(func);
             let (_, methods) = traits.get_mut(&resource).unwrap();
-            // let (_, methods) = traits.get_mut(&None).unwrap();
 
             let prev = mem::take(&mut self.src);
             let mut sig = FnSig {

--- a/crates/wit-bindgen-rust/src/interface.rs
+++ b/crates/wit-bindgen-rust/src/interface.rs
@@ -2266,6 +2266,8 @@ impl<'a> wit_bindgen_core::InterfaceGenerator<'a> for InterfaceGenerator<'a> {
     }
 
     fn type_resource(&mut self, _id: TypeId, name: &str, docs: &Docs) {
+        // TODO: Refactor the resource handle unit structs to not have the "Rep" suffix
+
         self.rustdoc(docs);
         let camel = to_upper_camel_case(name);
 
@@ -2277,6 +2279,7 @@ impl<'a> wit_bindgen_core::InterfaceGenerator<'a> for InterfaceGenerator<'a> {
         let tracing = self.gen.tracing_path();
 
         if self.in_import {
+            // TODO: Refactor to use extension traits for Resource{Own,Borrow} instead defining a wrapper struct
             uwriteln!(
                 self.src,
                 r#"

--- a/crates/wit-bindgen-rust/src/interface.rs
+++ b/crates/wit-bindgen-rust/src/interface.rs
@@ -482,7 +482,7 @@ pub async fn serve_interface<T: {wrpc_transport}::Client, U>(
         true
     }
 
-    fn generate_interface_trait<'a>(&mut self, trait_name: &str, methods: &[Source]) {
+    fn generate_interface_trait(&mut self, trait_name: &str, methods: &[Source]) {
         uwriteln!(self.src, "pub trait {trait_name}<Ctx> {{");
         for method in methods {
             self.src.push_str(method);

--- a/crates/wit-bindgen-rust/tests/codegen.rs
+++ b/crates/wit-bindgen-rust/tests/codegen.rs
@@ -264,21 +264,21 @@ mod owned_resource_deref_mut {
         ",
     });
 
-    pub struct MyResource {
-        data: u32,
-    }
+    // pub struct MyResource {
+    //     data: u32,
+    // }
 
-    impl<Ctx: Send> exports::my::inline::foo::HandlerBar<Ctx> for MyResource {
-        async fn new(cx: Ctx, data: u32) -> anyhow::Result<Self> {
-            Ok(Self { data })
+    impl<Ctx: Send> exports::my::inline::foo::HandlerBar<Ctx> for Component {
+        async fn new(&self, cx: Ctx, data: u32) -> anyhow::Result<Vec<u8>> {
+            todo!();
         }
 
-        async fn get_data(&self, cx: Ctx) -> anyhow::Result<u32> {
-            Ok(self.data)
+        async fn get_data(&self, cx: Ctx, self_: Vec<u8>) -> anyhow::Result<u32> {
+            todo!();
         }
 
-        async fn consume(cx: Ctx, mut _this: exports::my::inline::foo::Bar) -> anyhow::Result<u32> {
-            todo!("resources not supported at this time")
+        async fn consume(&self, cx: Ctx, mut _this: Vec<u8>) -> anyhow::Result<u32> {
+            todo!();
             //let me = this.get::<Ctx, MyResource>();
             //let prior_data: &u32 = &me.data;
             //let new_data = prior_data + 1;
@@ -293,12 +293,12 @@ mod owned_resource_deref_mut {
     struct Component;
 
     impl<Ctx: Send> exports::my::inline::foo::Handler<Ctx> for Component {
-        type Bar = MyResource;
+        type Bar = Self;
     }
 
     async fn serve_exports(wrpc: &impl wrpc_transport_legacy::Client) {
         // TODO: Support resources
-        //serve(wrpc, Component, async {}).await.unwrap();
+        serve(wrpc, Component, async {}).await.unwrap();
     }
 }
 
@@ -319,11 +319,11 @@ mod package_with_versions {
         ",
     });
 
-    pub struct MyResource;
+    // pub struct MyResource;
 
-    impl<Ctx: Send> exports::my::inline::foo::HandlerBar<Ctx> for MyResource {
-        async fn new(cx: Ctx) -> anyhow::Result<Self> {
-            anyhow::bail!("not supported yet")
+    impl<Ctx: Send> exports::my::inline::foo::HandlerBar<Ctx> for Component {
+        async fn new(&self, cx: Ctx) -> anyhow::Result<Vec<u8>> {
+            todo!();
         }
     }
 
@@ -331,7 +331,7 @@ mod package_with_versions {
     struct Component;
 
     impl<Ctx: Send> exports::my::inline::foo::Handler<Ctx> for Component {
-        type Bar = MyResource;
+        type Bar = Self;
     }
 
     async fn serve_exports(wrpc: &impl wrpc_transport_legacy::Client) {
@@ -599,26 +599,37 @@ mod resource_example {
     }
 
     impl<Ctx: Send> HandlerLogger<Ctx> for MyLogger {
-        async fn new(cx: Ctx, level: Level) -> anyhow::Result<MyLogger> {
-            Ok(MyLogger {
-                level: RwLock::new(level),
-                contents: RwLock::new(String::new()),
-            })
+        async fn new(&self, cx: Ctx, level: Level) -> anyhow::Result<Vec<u8>> {
+            todo!();
+
+            // Ok(MyLogger {
+            //     level: RwLock::new(level),
+            //     contents: RwLock::new(String::new()),
+            // })
         }
 
-        async fn log(&self, cx: Ctx, level: Level, msg: String) -> anyhow::Result<()> {
-            if level as u32 <= *self.level.read().unwrap() as u32 {
-                self.contents.write().unwrap().push_str(&msg);
-                self.contents.write().unwrap().push('\n');
-            }
-            Ok(())
+        async fn log(
+            &self,
+            cx: Ctx,
+            self_: Vec<u8>,
+            level: Level,
+            msg: String,
+        ) -> anyhow::Result<()> {
+            todo!();
+
+            // if level as u32 <= *self.level.read().unwrap() as u32 {
+            //     self.contents.write().unwrap().push_str(&msg);
+            //     self.contents.write().unwrap().push('\n');
+            // }
+            // Ok(())
         }
 
-        async fn level(&self, cx: Ctx) -> anyhow::Result<Level> {
-            Ok(*self.level.read().unwrap())
+        async fn level(&self, cx: Ctx, self_: Vec<u8>) -> anyhow::Result<Level> {
+            todo!();
+            // Ok(*self.level.read().unwrap())
         }
 
-        async fn set_level(&self, cx: Ctx, level: Level) -> anyhow::Result<()> {
+        async fn set_level(&self, cx: Ctx, self_: Vec<u8>, level: Level) -> anyhow::Result<()> {
             *self.level.write().unwrap() = level;
             Ok(())
         }

--- a/crates/wit-bindgen-rust/tests/codegen.rs
+++ b/crates/wit-bindgen-rust/tests/codegen.rs
@@ -246,7 +246,7 @@ mod alternative_bitflags_path {
 }
 
 mod owned_resource_deref_mut {
-    use exports::my::inline::foo::Bar;
+    use exports::my::inline::foo::BarRep;
     use wrpc_transport_legacy::{ResourceBorrow, ResourceOwn};
 
     wit_bindgen_wrpc::generate!({
@@ -272,15 +272,15 @@ mod owned_resource_deref_mut {
     // }
 
     impl<Ctx: Send> exports::my::inline::foo::HandlerBar<Ctx> for Component {
-        async fn new(&self, cx: Ctx, data: u32) -> anyhow::Result<ResourceOwn<Bar>> {
+        async fn new(&self, cx: Ctx, data: u32) -> anyhow::Result<ResourceOwn<BarRep>> {
             todo!();
         }
 
-        async fn get_data(&self, cx: Ctx, self_: ResourceBorrow<Bar>) -> anyhow::Result<u32> {
+        async fn get_data(&self, cx: Ctx, self_: ResourceBorrow<BarRep>) -> anyhow::Result<u32> {
             todo!();
         }
 
-        async fn consume(&self, cx: Ctx, mut _this: ResourceOwn<Bar>) -> anyhow::Result<u32> {
+        async fn consume(&self, cx: Ctx, mut _this: ResourceOwn<BarRep>) -> anyhow::Result<u32> {
             todo!();
             //let me = this.get::<Ctx, MyResource>();
             //let prior_data: &u32 = &me.data;
@@ -306,7 +306,7 @@ mod owned_resource_deref_mut {
 }
 
 mod package_with_versions {
-    use exports::my::inline::foo::Bar;
+    use exports::my::inline::foo::BarRep;
     use wrpc_transport_legacy::ResourceOwn;
 
     wit_bindgen_wrpc::generate!({
@@ -328,7 +328,7 @@ mod package_with_versions {
     // pub struct MyResource;
 
     impl<Ctx: Send> exports::my::inline::foo::HandlerBar<Ctx> for Component {
-        async fn new(&self, cx: Ctx) -> anyhow::Result<ResourceOwn<Bar>> {
+        async fn new(&self, cx: Ctx) -> anyhow::Result<ResourceOwn<BarRep>> {
             todo!();
         }
     }
@@ -487,7 +487,7 @@ mod with_and_resources {
 
                 world dummy {
                     use foo.{a};
-                    import bar: func(m: a);
+                    // import bar: func(m: a);
                 }
             ",
         });
@@ -588,7 +588,7 @@ mod resource_example {
      "#,
     });
 
-    use exports::my::test::logging::{Handler, HandlerLogger, Level, Logger};
+    use exports::my::test::logging::{Handler, HandlerLogger, Level, Logger, LoggerRep};
     use wrpc_transport_legacy::{ResourceBorrow, ResourceOwn};
 
     #[derive(Clone)]
@@ -606,7 +606,7 @@ mod resource_example {
     }
 
     impl<Ctx: Send> HandlerLogger<Ctx> for MyLogger {
-        async fn new(&self, cx: Ctx, level: Level) -> anyhow::Result<ResourceOwn<Logger>> {
+        async fn new(&self, cx: Ctx, level: Level) -> anyhow::Result<ResourceOwn<LoggerRep>> {
             todo!();
 
             // Ok(MyLogger {
@@ -618,7 +618,7 @@ mod resource_example {
         async fn log(
             &self,
             cx: Ctx,
-            self_: ResourceBorrow<Logger>,
+            self_: ResourceBorrow<LoggerRep>,
             level: Level,
             msg: String,
         ) -> anyhow::Result<()> {
@@ -631,7 +631,7 @@ mod resource_example {
             // Ok(())
         }
 
-        async fn level(&self, cx: Ctx, self_: ResourceBorrow<Logger>) -> anyhow::Result<Level> {
+        async fn level(&self, cx: Ctx, self_: ResourceBorrow<LoggerRep>) -> anyhow::Result<Level> {
             todo!();
             // Ok(*self.level.read().unwrap())
         }
@@ -639,7 +639,7 @@ mod resource_example {
         async fn set_level(
             &self,
             cx: Ctx,
-            self_: ResourceBorrow<Logger>,
+            self_: ResourceBorrow<LoggerRep>,
             level: Level,
         ) -> anyhow::Result<()> {
             *self.level.write().unwrap() = level;

--- a/crates/wit-bindgen-rust/tests/codegen.rs
+++ b/crates/wit-bindgen-rust/tests/codegen.rs
@@ -295,9 +295,7 @@ mod owned_resource_deref_mut {
     #[derive(Clone)]
     struct Component;
 
-    impl<Ctx: Send> exports::my::inline::foo::Handler<Ctx> for Component {
-        type Bar = Self;
-    }
+    impl<Ctx: Send> exports::my::inline::foo::Handler<Ctx> for Component {}
 
     async fn serve_exports(wrpc: &impl wrpc_transport_legacy::Client) {
         // TODO: Support resources
@@ -336,9 +334,7 @@ mod package_with_versions {
     #[derive(Clone)]
     struct Component;
 
-    impl<Ctx: Send> exports::my::inline::foo::Handler<Ctx> for Component {
-        type Bar = Self;
-    }
+    impl<Ctx: Send> exports::my::inline::foo::Handler<Ctx> for Component {}
 
     async fn serve_exports(wrpc: &impl wrpc_transport_legacy::Client) {
         // TODO: Support resources
@@ -596,9 +592,7 @@ mod resource_example {
 
     // Note that the `logging` interface has no methods of its own but a trait
     // is required to be implemented here to specify the type of `Logger`.
-    impl<Ctx: Send> Handler<Ctx> for MyComponent {
-        type Logger = MyLogger;
-    }
+    impl<Ctx: Send> Handler<Ctx> for MyComponent {}
 
     struct MyLogger {
         level: RwLock<Level>,

--- a/crates/wit-bindgen-rust/tests/codegen.rs
+++ b/crates/wit-bindgen-rust/tests/codegen.rs
@@ -267,9 +267,9 @@ mod owned_resource_deref_mut {
         ",
     });
 
-    // pub struct MyResource {
-    //     data: u32,
-    // }
+    pub struct MyResource {
+        data: u32,
+    }
 
     impl<Ctx: Send> exports::my::inline::foo::HandlerBar<Ctx> for Component {
         async fn new(&self, cx: Ctx, data: u32) -> anyhow::Result<ResourceOwn<BarRep>> {
@@ -282,13 +282,6 @@ mod owned_resource_deref_mut {
 
         async fn consume(&self, cx: Ctx, mut _this: ResourceOwn<BarRep>) -> anyhow::Result<u32> {
             todo!();
-            //let me = this.get::<Ctx, MyResource>();
-            //let prior_data: &u32 = &me.data;
-            //let new_data = prior_data + 1;
-            //let me = this.get_mut::<Ctx, MyResource>();
-            //let mutable_data: &mut u32 = &mut me.data;
-            //*mutable_data = new_data;
-            //Ok(me.data)
         }
     }
 
@@ -323,7 +316,7 @@ mod package_with_versions {
         ",
     });
 
-    // pub struct MyResource;
+    pub struct MyResource;
 
     impl<Ctx: Send> exports::my::inline::foo::HandlerBar<Ctx> for Component {
         async fn new(&self, cx: Ctx) -> anyhow::Result<ResourceOwn<BarRep>> {
@@ -337,8 +330,7 @@ mod package_with_versions {
     impl<Ctx: Send> exports::my::inline::foo::Handler<Ctx> for Component {}
 
     async fn serve_exports(wrpc: &impl wrpc_transport_legacy::Client) {
-        // TODO: Support resources
-        //serve(wrpc, Component, async {}).await.unwrap();
+        serve(wrpc, Component, async {}).await.unwrap();
     }
 }
 
@@ -483,7 +475,7 @@ mod with_and_resources {
 
                 world dummy {
                     use foo.{a};
-                    // import bar: func(m: a);
+                    import bar: func(m: a);
                 }
             ",
         });
@@ -655,7 +647,7 @@ mod example_4 {
         package example:exported-resources;
 
         world import-some-resources {
-            export logging;
+            import logging;
         }
 
         interface logging {

--- a/crates/wit-bindgen-rust/tests/codegen.rs
+++ b/crates/wit-bindgen-rust/tests/codegen.rs
@@ -246,6 +246,9 @@ mod alternative_bitflags_path {
 }
 
 mod owned_resource_deref_mut {
+    use exports::my::inline::foo::Bar;
+    use wrpc_transport_legacy::{ResourceBorrow, ResourceOwn};
+
     wit_bindgen_wrpc::generate!({
         inline: "
             package my:inline;
@@ -269,15 +272,15 @@ mod owned_resource_deref_mut {
     // }
 
     impl<Ctx: Send> exports::my::inline::foo::HandlerBar<Ctx> for Component {
-        async fn new(&self, cx: Ctx, data: u32) -> anyhow::Result<Vec<u8>> {
+        async fn new(&self, cx: Ctx, data: u32) -> anyhow::Result<ResourceOwn<Bar>> {
             todo!();
         }
 
-        async fn get_data(&self, cx: Ctx, self_: Vec<u8>) -> anyhow::Result<u32> {
+        async fn get_data(&self, cx: Ctx, self_: ResourceBorrow<Bar>) -> anyhow::Result<u32> {
             todo!();
         }
 
-        async fn consume(&self, cx: Ctx, mut _this: Vec<u8>) -> anyhow::Result<u32> {
+        async fn consume(&self, cx: Ctx, mut _this: ResourceOwn<Bar>) -> anyhow::Result<u32> {
             todo!();
             //let me = this.get::<Ctx, MyResource>();
             //let prior_data: &u32 = &me.data;
@@ -303,6 +306,9 @@ mod owned_resource_deref_mut {
 }
 
 mod package_with_versions {
+    use exports::my::inline::foo::Bar;
+    use wrpc_transport_legacy::ResourceOwn;
+
     wit_bindgen_wrpc::generate!({
         inline: "
             package my:inline@0.0.0;
@@ -322,7 +328,7 @@ mod package_with_versions {
     // pub struct MyResource;
 
     impl<Ctx: Send> exports::my::inline::foo::HandlerBar<Ctx> for Component {
-        async fn new(&self, cx: Ctx) -> anyhow::Result<Vec<u8>> {
+        async fn new(&self, cx: Ctx) -> anyhow::Result<ResourceOwn<Bar>> {
             todo!();
         }
     }
@@ -582,7 +588,8 @@ mod resource_example {
      "#,
     });
 
-    use exports::my::test::logging::{Handler, HandlerLogger, Level};
+    use exports::my::test::logging::{Handler, HandlerLogger, Level, Logger};
+    use wrpc_transport_legacy::{ResourceBorrow, ResourceOwn};
 
     #[derive(Clone)]
     struct MyComponent;
@@ -599,7 +606,7 @@ mod resource_example {
     }
 
     impl<Ctx: Send> HandlerLogger<Ctx> for MyLogger {
-        async fn new(&self, cx: Ctx, level: Level) -> anyhow::Result<Vec<u8>> {
+        async fn new(&self, cx: Ctx, level: Level) -> anyhow::Result<ResourceOwn<Logger>> {
             todo!();
 
             // Ok(MyLogger {
@@ -611,7 +618,7 @@ mod resource_example {
         async fn log(
             &self,
             cx: Ctx,
-            self_: Vec<u8>,
+            self_: ResourceBorrow<Logger>,
             level: Level,
             msg: String,
         ) -> anyhow::Result<()> {
@@ -624,12 +631,17 @@ mod resource_example {
             // Ok(())
         }
 
-        async fn level(&self, cx: Ctx, self_: Vec<u8>) -> anyhow::Result<Level> {
+        async fn level(&self, cx: Ctx, self_: ResourceBorrow<Logger>) -> anyhow::Result<Level> {
             todo!();
             // Ok(*self.level.read().unwrap())
         }
 
-        async fn set_level(&self, cx: Ctx, self_: Vec<u8>, level: Level) -> anyhow::Result<()> {
+        async fn set_level(
+            &self,
+            cx: Ctx,
+            self_: ResourceBorrow<Logger>,
+            level: Level,
+        ) -> anyhow::Result<()> {
             *self.level.write().unwrap() = level;
             Ok(())
         }

--- a/crates/wit-bindgen-rust/tests/codegen.rs
+++ b/crates/wit-bindgen-rust/tests/codegen.rs
@@ -591,7 +591,7 @@ mod resource_example {
         contents: RwLock<String>,
     }
 
-    impl<Ctx: Send> HandlerLogger<Ctx> for MyLogger {
+    impl<Ctx: Send> HandlerLogger<Ctx> for MyComponent {
         async fn new(&self, cx: Ctx, level: Level) -> anyhow::Result<ResourceOwn<LoggerRep>> {
             todo!();
 
@@ -628,15 +628,15 @@ mod resource_example {
             self_: ResourceBorrow<LoggerRep>,
             level: Level,
         ) -> anyhow::Result<()> {
-            *self.level.write().unwrap() = level;
-            Ok(())
+            todo!();
+
+            // *self.level.write().unwrap() = level;
+            // Ok(())
         }
     }
 
     async fn serve_exports(wrpc: &impl wrpc_transport_legacy::Client) -> anyhow::Result<()> {
-        // TODO: Support resources
-        //serve(wrpc, MyComponent, async {}).await
-        anyhow::bail!("resources not supported yet")
+        serve(wrpc, MyComponent, async {}).await
     }
 }
 
@@ -647,7 +647,7 @@ mod example_4 {
         package example:exported-resources;
 
         world import-some-resources {
-            import logging;
+            export logging;
         }
 
         interface logging {

--- a/tests/rust.rs
+++ b/tests/rust.rs
@@ -157,7 +157,7 @@ async fn rust_bindgen() -> anyhow::Result<()> {
 
                         let index_bytes: [u8; 8] = handle_blob[0..8].try_into().context("failed to decode counter resource hanlde")?;
                         let index = usize::from_ne_bytes(index_bytes);
-                        
+
                         let mut counts = self.counts.write().await;
                         let count = *counts.get(index).context("counter resource entry not found")?;
 
@@ -174,7 +174,7 @@ async fn rust_bindgen() -> anyhow::Result<()> {
 
                         let index_bytes: [u8; 8] = handle_blob[0..8].try_into().context("failed to decode counter resource hanlde")?;
                         let index = usize::from_ne_bytes(index_bytes);
-                        
+
                         let counts = self.counts.read().await;
                         let count = counts.get(index).context("counter resource entry not found")?;
 
@@ -186,7 +186,7 @@ async fn rust_bindgen() -> anyhow::Result<()> {
 
                         let index_bytes: [u8; 8] = handle_blob[0..8].try_into().context("failed to decode counter resource handle")?;
                         let index = usize::from_ne_bytes(index_bytes);
-                        
+
                         let mut counts = self.counts.write().await;
                         let count = counts.get_mut(index).context("counter resource entry not found")?;
 
@@ -204,7 +204,7 @@ async fn rust_bindgen() -> anyhow::Result<()> {
 
                         let a_index = usize::from_ne_bytes(a_index_bytes);
                         let b_index = usize::from_ne_bytes(b_index_bytes);
-                        
+
                         let counts = self.counts.write().await;
                         let a_count = counts.get(a_index).context("counter resource entry not found")?;
                         let b_count = counts.get(b_index).context("counter resource entry not found")?;


### PR DESCRIPTION
Closes #15. This PR implements resource support by representing resources as opaque handles. The handles are implemented as lists of bytes wrapped `ResourceOwn<T>` and `ResourceBorrow<T>` as outlined in #101.

This PR will supersede #82. This was implemented on new branch due to the significant differences between the opaque handle based approach for representing resources used here vs #82's approach that took a much more prescriptive approach to resource handling.

An example of resources being used with wRPC can be founding in the `rust_bindgen` test case in `tests/rust.rs`.

Other than revisions, I believe the main todo item left for this is to decide how to handle drops. I'm a little unsure if resource handlers should be forced to serve a `drop` method that clients can call, or if wRPC resource hosts and clients should implement their own drop methods that they can call on their own basis. @rvolosatovs thoughts?